### PR TITLE
feat(UI): accent colours

### DIFF
--- a/src/ModrinthCatppuccin.user.css
+++ b/src/ModrinthCatppuccin.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           Modrinth Catppuccin
 @namespace      github.com/catppuccin/modrinth
-@version        1
+@version        1.1.0
 @description    Soothing pastel theme for Modrinth
 @author         Catppuccin
 @preprocessor   stylus

--- a/src/ModrinthCatppuccin.user.css
+++ b/src/ModrinthCatppuccin.user.css
@@ -7,6 +7,7 @@
 @preprocessor   stylus
 @var select lighttheme "Light Variant" ["Latte*", "Frappe", "Macchiato", "Mocha"]
 @var select darktheme "Dark Variant" ["Latte", "Frappe", "Macchiato", "Mocha*"]
+@var select accent-color "Accent" ["Rosewater", "Flamingo", "Pink", "Mauve", "Red", "Maroon", "Peach", "Yellow", "Green*", "Teal", "Blue", "Sapphire", "Sky", "Lavender", "Gray"]
 ==/UserStyle== */
 
 @-moz-document domain("modrinth.com") {
@@ -40,7 +41,7 @@
             --ctp-crust: #dce0e8;
             --ctp-shadow: #dbdfef;
         }
-    
+
         if (flavour=="Frappe") {
             --ctp-rosewater: #f2d5cf;
             --ctp-flamingo: #eebebe;
@@ -70,7 +71,7 @@
             --ctp-crust: #232634;
             --ctp-shadow: #010409;
         }
-    
+
         if (flavour=="Macchiato") {
             --ctp-rosewater: #f4dbd6;
             --ctp-flamingo: #f0c6c6;
@@ -100,7 +101,7 @@
             --ctp-crust: #181926;
             --ctp-shadow: #010409;
         }
-    
+
         if (flavour=="Mocha") {
             --ctp-rosewater: #f5e0dc;
             --ctp-flamingo: #f2cdcd;
@@ -130,7 +131,7 @@
             --ctp-crust: #11111b;
             --ctp-shadow: #010409;
         }
-    
+
       }
 
     .light-mode {
@@ -145,12 +146,30 @@
         if (darktheme=="Macchiato") { colourscheme(Macchiato) }
         if (darktheme=="Mocha")     { colourscheme(Mocha) }
       }
-    
+
+
       :root{
+
+          if (accent-color=="Rosewater")      { --ctp-accent-color: var(--ctp-rosewater) }
+          else if (accent-color=="Flamingo")  { --ctp-accent-color: var(--ctp-flamingo) }
+          else if (accent-color=="Pink")      { --ctp-accent-color: var(--ctp-pink) }
+          else if (accent-color=="Mauve")     { --ctp-accent-color: var(--ctp-mauve) }
+          else if (accent-color=="Red")       { --ctp-accent-color: var(--ctp-red) }
+          else if (accent-color=="Maroon")    { --ctp-accent-color: var(--ctp-maroon) }
+          else if (accent-color=="Peach")     { --ctp-accent-color: var(--ctp-peach) }
+          else if (accent-color=="Yellow")    { --ctp-accent-color: var(--ctp-yellow) }
+          else if (accent-color=="Green")     { --ctp-accent-color: var(--ctp-green) }
+          else if (accent-color=="Teal")      { --ctp-accent-color: var(--ctp-teal) }
+          else if (accent-color=="Blue")      { --ctp-accent-color: var(--ctp-blue) }
+          else if (accent-color=="Sapphire")  { --ctp-accent-color: var(--ctp-sapphire) }
+          else if (accent-color=="Sky")       { --ctp-accent-color: var(--ctp-sky) }
+          else if (accent-color=="Lavender")  { --ctp-accent-color: var(--ctp-lavender) }
+          else if (accent-color=="Gray")      { --ctp-accent-color: var(--ctp-subtext0) }
+
           --color-bg: var(--ctp-crust);
           --color-ad-raised: var(--ctp-surface2);
           --color-ad: var(--ctp-surface1);
-          --color-brand-green: var(--ctp-green);
+          --color-brand-green: var(--ctp-accent-color);
           --color-button-bg-active: var(--ctp-overlay0);
           --color-button-bg-hover: var(--ctp-surface2);
           --color-button-bg: var(--ctp-surface1);
@@ -174,5 +193,5 @@
           --color-table-alternate-row: var(--ctp-crust);
           --color-table-border: var(--ctp-overlay0)
       }
-  
+
   }


### PR DESCRIPTION
This PR simply adds support for personalised accent colours as seen in other userstyles.
Instead of always using `green` for the `--color-brand-green` users can now chose from all available Catppuccin colours. c:

<img width="273" alt="Screenshot 2023-03-23 at 11 31 50" src="https://user-images.githubusercontent.com/35840154/227176574-1e25d5aa-ae19-4335-a007-77142bdb5077.png">

Example with `mauve` as accent colour:
<img width="172" alt="Screenshot 2023-03-23 at 11 34 09" src="https://user-images.githubusercontent.com/35840154/227177120-b8ed4944-0bfc-4aad-9748-0c8ed3b9c223.png"> <img width="114" alt="Screenshot 2023-03-23 at 11 34 20" src="https://user-images.githubusercontent.com/35840154/227177160-58a5af4b-33fb-4e3b-ba87-2a4b4ea9528e.png"> <img width="216" alt="Screenshot 2023-03-23 at 11 34 30" src="https://user-images.githubusercontent.com/35840154/227177200-87c860a7-763d-4361-a87e-1be24acc6f43.png">
